### PR TITLE
Add zlib-devel to succeed compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM amazonlinux
 
 WORKDIR /
 RUN yum update -y
-RUN yum install gcc gcc-c++ openssl-devel bzip2-devel libffi-devel wget tar gzip zip make -y
+RUN yum install gcc gcc-c++ openssl-devel bzip2-devel libffi-devel wget tar gzip zip make zlib-devel -y
 
 # Install Python 3.9
 WORKDIR /


### PR DESCRIPTION
To fix the error with python 3.9 on compilation

```
#0 102.6 Traceback (most recent call last):
#0 102.6   File "<frozen zipimport>", line 520, in _get_decompress_func
#0 102.6 ModuleNotFoundError: No module named 'zlib'
#0 102.6 
#0 102.6 During handling of the above exception, another exception occurred:
#0 102.6 
#0 102.6 Traceback (most recent call last):
#0 102.6   File "<frozen zipimport>", line 568, in _get_data
#0 102.6   File "<frozen zipimport>", line 523, in _get_decompress_func
#0 102.6 zipimport.ZipImportError: can't decompress data; zlib not available
#0 102.6 

```